### PR TITLE
feat: Update to kotlin-sdk@0.6.2, set up Dokka and publishing

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation(plugin(libs.plugins.binary.compatibility.validator))
+    implementation(plugin(libs.plugins.ktlint))
+    implementation(plugin(libs.plugins.kotlin.multiplatform))
+    implementation(plugin(libs.plugins.dokka))
+    implementation(plugin(libs.plugins.vanniktech.maven.publish))
+}
+
+/**
+ * Helper function that transforms a Gradle Plugin alias from a Version Catalog into a valid
+ * dependency notation for buildSrc. Taken from
+ * https://docs.gradle.org/current/userguide/version_catalogs.html#sec:buildsrc-version-catalog
+ */
+private fun DependencyHandlerScope.plugin(plugin: Provider<PluginDependency>) =
+    plugin.map { "${it.pluginId}:${it.pluginId}.gradle.plugin:${it.version}" }

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,0 +1,4 @@
+# Enable the v2 syntax of the Dokka Gradle Plugin
+# https://kotlinlang.org/docs/dokka-migration.html
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,22 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenLocal()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/dev.openfeature.provider-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.openfeature.provider-conventions.gradle.kts
@@ -38,10 +38,6 @@ mavenPublishing {
         version = findProperty("version").toString()
     )
     pom {
-        name.set("OpenFeature Kotlin SDK")
-        description.set(
-            "This is the Kotlin implementation of OpenFeature, a vendor-agnostic abstraction library for evaluating feature flags."
-        )
         url.set("https://openfeature.dev")
         licenses {
             license {

--- a/buildSrc/src/main/kotlin/dev.openfeature.provider-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.openfeature.provider-conventions.gradle.kts
@@ -1,0 +1,90 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.dokka")
+}
+
+// Configure Dokka for documentation
+dokka {
+    dokkaPublications.html {
+        suppressInheritedMembers.set(true)
+        failOnWarning.set(true)
+    }
+    dokkaSourceSets.commonMain {
+        sourceLink {
+            localDirectory.set(file("src/"))
+            remoteUrl("https://github.com/open-feature/kotlin-sdk/tree/main/kotlin-sdk/src")
+            remoteLineSuffix.set("#L")
+        }
+    }
+}
+
+mavenPublishing {
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
+            sourcesJar = true,
+            androidVariantsToPublish = listOf("release")
+        )
+    )
+    signAllPublications()
+    coordinates(
+        groupId = "dev.openfeature.kotlin.contrib.providers",
+        version = findProperty("version").toString()
+    )
+    pom {
+        name.set("OpenFeature Kotlin SDK")
+        description.set(
+            "This is the Kotlin implementation of OpenFeature, a vendor-agnostic abstraction library for evaluating feature flags."
+        )
+        url.set("https://openfeature.dev")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        developers {
+            developer {
+                id.set("vahidlazio")
+                name.set("Vahid Torkaman")
+                email.set("vahidt@spotify.com")
+            }
+            developer {
+                id.set("fabriziodemaria")
+                name.set("Fabrizio Demaria")
+                email.set("fdema@spotify.com")
+            }
+            developer {
+                id.set("nicklasl")
+                name.set("Nicklas Lundin")
+                email.set("nicklasl@spotify.com")
+            }
+            developer {
+                id.set("nickybondarenko")
+                name.set("Nicky Bondarenko")
+                email.set("nickyb@spotify.com")
+            }
+            developer {
+                id.set("bencehornak")
+                name.set("Bence Hornák")
+                email.set("bence.hornak@gmail.com")
+            }
+        }
+        scm {
+            connection.set(
+                "scm:git:https://github.com/open-feature/kotlin-sdk-contrib.git"
+            )
+            developerConnection.set(
+                "scm:git:ssh://open-feature/kotlin-sdk-contrib.git"
+            )
+            url.set("https://github.com/open-feature/kotlin-sdk-contrib")
+        }
+    }
+}
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,12 @@
+version=0.1.0
 org.gradle.configuration-cache=true
 
 # This seems to be necessary for Coroutines to work on JS. Otherwise getting the following error:
 #   > Task :providers:env-var:compileTestDevelopmentExecutableKotlinJs FAILED
 #   e: java.lang.IllegalStateException: IC internal error: can not find library org.jetbrains.kotlin:kotlinx-atomicfu-runtime
 kotlinx.atomicfu.enableJsIrTransformation=true
+
+# Enable the v2 syntax of the Dokka Gradle Plugin
+# https://kotlinlang.org/docs/dokka-migration.html
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,10 @@ kotlinx-coroutines-core = { group="org.jetbrains.kotlinx", name="kotlinx-corouti
 kotlinx-coroutines-test = { group="org.jetbrains.kotlinx", name="kotlinx-coroutines-test", version.ref="kotlinx-coroutines" }
 
 [plugins]
+dokka = { id="org.jetbrains.dokka", version="2.0.0" }
 kotlin-multiplatform = { id="org.jetbrains.kotlin.multiplatform", version.ref="kotlin" }
 kotlinx-atomicfu = { id="org.jetbrains.kotlinx.atomicfu", version="0.27.0" }
 ktlint = { id="org.jlleitschuh.gradle.ktlint", version="12.3.0" }
 nexus-publish = { id="io.github.gradle-nexus.publish-plugin", version="2.0.0" }
 binary-compatibility-validator = { id="org.jetbrains.kotlinx.binary-compatibility-validator", version="0.17.0" }
+vanniktech-maven-publish = { id="com.vanniktech.maven.publish", version="0.34.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.1.21"
 kotlinx-coroutines = "1.10.2"
-open-feature-kotlin-sdk = "0.4.1"
+open-feature-kotlin-sdk = "0.6.2"
 
 [libraries]
 openfeature-kotlin-sdk = { group="dev.openfeature", name="kotlin-sdk", version.ref="open-feature-kotlin-sdk" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/providers/env-var/README.md
+++ b/providers/env-var/README.md
@@ -1,6 +1,6 @@
 # Environment Variables Kotlin Provider
 
-Environment Variables provider allows you to read feature flags from the [process's environment](https://en.wikipedia.org/wiki/Environment_variable).
+The Environment Variables provider allows you to read feature flags from the [process's environment](https://en.wikipedia.org/wiki/Environment_variable).
 
 ## Supported platforms
 

--- a/providers/env-var/api/env-var.api
+++ b/providers/env-var/api/env-var.api
@@ -1,20 +1,20 @@
-public final class dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider : dev/openfeature/sdk/FeatureProvider {
+public final class dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
 	public static final field Companion Ldev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider$Companion;
 	public fun <init> ()V
 	public fun <init> (Ldev/openfeature/kotlin/contrib/providers/envvar/EnvironmentGateway;Ldev/openfeature/kotlin/contrib/providers/envvar/EnvironmentKeyTransformer;)V
 	public synthetic fun <init> (Ldev/openfeature/kotlin/contrib/providers/envvar/EnvironmentGateway;Ldev/openfeature/kotlin/contrib/providers/envvar/EnvironmentKeyTransformer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getBooleanEvaluation (Ljava/lang/String;ZLdev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
-	public fun getDoubleEvaluation (Ljava/lang/String;DLdev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
+	public fun getBooleanEvaluation (Ljava/lang/String;ZLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getDoubleEvaluation (Ljava/lang/String;DLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getHooks ()Ljava/util/List;
-	public fun getIntegerEvaluation (Ljava/lang/String;ILdev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
-	public fun getMetadata ()Ldev/openfeature/sdk/ProviderMetadata;
-	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/sdk/Value;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
-	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;)Ldev/openfeature/sdk/ProviderEvaluation;
-	public fun initialize (Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getIntegerEvaluation (Ljava/lang/String;ILdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
+	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;
-	public fun onContextSet (Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onContextSet (Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun shutdown ()V
-	public fun track (Ljava/lang/String;Ldev/openfeature/sdk/EvaluationContext;Ldev/openfeature/sdk/TrackingEventDetails;)V
+	public fun track (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;Ldev/openfeature/kotlin/sdk/TrackingEventDetails;)V
 }
 
 public final class dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider$Companion {

--- a/providers/env-var/build.gradle.kts
+++ b/providers/env-var/build.gradle.kts
@@ -35,6 +35,15 @@ kotlin {
     }
 }
 
+mavenPublishing {
+    pom {
+        name.set("OpenFeature Environment Variables Kotlin Provider")
+        description.set(
+            "The Environment Variables provider allows you to read feature flags from the process's environment.",
+        )
+    }
+}
+
 // Set test environment variable for tests
 // Used in ./commonTest/kotlin/dev/openfeature/kotlin/contrib/providers/envvar/PlatformSpecificEnvironmentGatewayTest.kt
 val testEnvironmentVariable = "TEST_ENVIRONMENT_VARIABLE" to "foo"

--- a/providers/env-var/build.gradle.kts
+++ b/providers/env-var/build.gradle.kts
@@ -3,9 +3,7 @@ import org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest
 import org.jetbrains.kotlin.gradle.targets.native.tasks.KotlinNativeTest
 
 plugins {
-    alias(libs.plugins.kotlin.multiplatform)
-    alias(libs.plugins.binary.compatibility.validator)
-    alias(libs.plugins.ktlint)
+    id("dev.openfeature.provider-conventions")
     // Needed for the JS coroutine support for the tests
     alias(libs.plugins.kotlinx.atomicfu)
 }

--- a/providers/env-var/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider.kt
+++ b/providers/env-var/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider.kt
@@ -1,13 +1,13 @@
 package dev.openfeature.kotlin.contrib.providers.envvar
 
-import dev.openfeature.sdk.EvaluationContext
-import dev.openfeature.sdk.FeatureProvider
-import dev.openfeature.sdk.Hook
-import dev.openfeature.sdk.ProviderEvaluation
-import dev.openfeature.sdk.ProviderMetadata
-import dev.openfeature.sdk.Reason
-import dev.openfeature.sdk.Value
-import dev.openfeature.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.EvaluationContext
+import dev.openfeature.kotlin.sdk.FeatureProvider
+import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.ProviderEvaluation
+import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.Reason
+import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 
 /** EnvVarProvider is the Kotlin provider implementation for the environment variables.  */
 class EnvVarProvider(

--- a/providers/env-var/src/commonTest/kotlin/dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProviderE2eTest.kt
+++ b/providers/env-var/src/commonTest/kotlin/dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProviderE2eTest.kt
@@ -1,8 +1,8 @@
 package dev.openfeature.kotlin.contrib.providers.envvar
 
-import dev.openfeature.sdk.Client
-import dev.openfeature.sdk.OpenFeatureAPI
-import dev.openfeature.sdk.Reason
+import dev.openfeature.kotlin.sdk.Client
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.Reason
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/providers/env-var/src/commonTest/kotlin/dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProviderTest.kt
+++ b/providers/env-var/src/commonTest/kotlin/dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProviderTest.kt
@@ -1,11 +1,11 @@
 package dev.openfeature.kotlin.contrib.providers.envvar
 
-import dev.openfeature.sdk.FeatureProvider
-import dev.openfeature.sdk.ImmutableContext
-import dev.openfeature.sdk.ProviderEvaluation
-import dev.openfeature.sdk.Reason
-import dev.openfeature.sdk.Value
-import dev.openfeature.sdk.exceptions.OpenFeatureError
+import dev.openfeature.kotlin.sdk.FeatureProvider
+import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.ProviderEvaluation
+import dev.openfeature.kotlin.sdk.Reason
+import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

- Upgrades to the first Multiplatform-compatible Kotlin SDK version, which allows the CI to finally pass.
- Sets up Dokka and publishing (using the [Gradle Maven Publish Plugin by vanniktech](https://vanniktech.github.io/gradle-maven-publish-plugin/)) similar to https://github.com/open-feature/kotlin-sdk/pull/166

### Follow-up Tasks

Release Please can eventually be set up after this (#2).

### How to test
<!-- if applicable, add testing instructions under this section -->

The CI should pass for the first time. The publishing can be tested with `./gradlew publishToMavenLocal`. It should create the artifacts of the env-var provider under `~/.m2/repository/dev/openfeature/kotlin/contrib/providers/`.