### PR TITLE
fix: ignore `local.properties`, remove `allowedCommands` from `renovate.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build
 
 # Ignore Kotlin files
 .kotlin
+
+# Locally set Gradle parameters
+local.properties

--- a/local.properties
+++ b/local.properties
@@ -1,8 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Sun May 18 19:42:09 CEST 2025
-sdk.dir=/home/bence/Android/Sdk

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,5 @@
         ],
         "fileFilters": ["kotlin-js-store/yarn.lock"],
         "executionMode": "update"
-    },
-    "allowedCommands": ["^./gradlew kotlinUpgradeYarnLock$"]
+    }
 }


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Removes the `local.properties` (where the local path of the Android SDK is specified) file and adds it to the gitignore
- Removes [`allowedCommands`](https://docs.renovatebot.com/self-hosted-configuration/#allowedcommands) from `renovate.json`, because it has no impact (see #5), as it should rather be a config of the self-hosted renovate instance.
