### PR TITLE
chore: Use Renovate in self-hosted mode

### DIFF
--- a/.github/renovate-self-hosted.json
+++ b/.github/renovate-self-hosted.json
@@ -1,0 +1,7 @@
+{
+  "allowedCommands": ["^./gradlew kotlinUpgradeYarnLock$"],
+  "onboarding": true,
+  "platform": "github",
+  "repositories": ["open-feature/kotlin-sdk-contrib"],
+  "semanticCommits": "enabled"
+}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,21 @@
+name: Renovate
+on:
+  schedule:
+    - cron: '0 8 * * *' # At 8:00 AM daily (UTC)
+
+  # Allow manual triggering
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v43.0.11
+        with:
+          configurationFile: .github/renovate-self-hosted.json
+          token: ${{ secrets.RENOVATE_BOT }}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- switches to [self-hosted Renovate (with GitHub Actions)](https://github.com/marketplace/actions/renovate-bot-github-action) to allow running [`postUpgradeTasks`](https://docs.renovatebot.com/configuration-options/#postupgradetasks), which are necessary to update the yarn lock file as a follow-up to dependency upgrades.

### Notes
<!-- any additional notes for this PR -->
According to the [`postUpgradeTasks` docs](https://docs.renovatebot.com/configuration-options/#postupgradetasks):

> In Mend-hosted Renovate apps, commands remain blocked by default but can be allowed on-request for any paying ("Renovate Enterprise" or Mend Appsec) customers or trusted OSS repositories - please reach out if so.

If this repo constitutes as a "trusted OSS repository", then we actually don't need this. I'm clarifying this on [Slack](https://cloud-native.slack.com/archives/C080WHYDG5V/p1757744497728119?thread_ts=1756271737.915429&cid=C080WHYDG5V).

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->
- [ ] Check if it works
- [ ] Disable the hosted Renovate automation
- [ ] Set `onboarding` to `false` in `renovate.json` if [all of the mentioned conditions](https://docs.renovatebot.com/self-hosted-configuration/#onboarding) are met
- [ ] Repeat the PR for the [`kotlin-sdk`](https://github.com/open-feature/kotlin-sdk) repo

### How to test
<!-- if applicable, add testing instructions under this section -->
Unfortunately, it can only be tested after the PR is merged.
