### PR TITLE
feat: Add SLF4J and Timber logging adapters

### DIFF
--- a/buildSrc/src/main/kotlin/dev.openfeature.hook-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/dev.openfeature.hook-conventions.gradle.kts
@@ -1,0 +1,85 @@
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("com.vanniktech.maven.publish")
+    id("org.jetbrains.dokka")
+}
+
+// Configure Dokka for documentation
+dokka {
+    dokkaPublications.html {
+        suppressInheritedMembers.set(true)
+        failOnWarning.set(true)
+    }
+    dokkaSourceSets.commonMain {
+        sourceLink {
+            localDirectory.set(file("src/"))
+            remoteUrl("https://github.com/open-feature/kotlin-sdk-contrib/tree/main/hooks")
+            remoteLineSuffix.set("#L")
+        }
+    }
+}
+
+mavenPublishing {
+    configure(
+        KotlinMultiplatform(
+            javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml"),
+            sourcesJar = true,
+            androidVariantsToPublish = listOf("release")
+        )
+    )
+    signAllPublications()
+    coordinates(
+        groupId = "dev.openfeature.kotlin.contrib.hooks",
+        version = findProperty("version").toString()
+    )
+    pom {
+        url.set("https://openfeature.dev")
+        licenses {
+            license {
+                name.set("The Apache License, Version 2.0")
+                url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+            }
+        }
+        developers {
+            developer {
+                id.set("vahidlazio")
+                name.set("Vahid Torkaman")
+                email.set("vahidt@spotify.com")
+            }
+            developer {
+                id.set("fabriziodemaria")
+                name.set("Fabrizio Demaria")
+                email.set("fdema@spotify.com")
+            }
+            developer {
+                id.set("nicklasl")
+                name.set("Nicklas Lundin")
+                email.set("nicklasl@spotify.com")
+            }
+            developer {
+                id.set("nickybondarenko")
+                name.set("Nicky Bondarenko")
+                email.set("nickyb@spotify.com")
+            }
+            developer {
+                id.set("bencehornak")
+                name.set("Bence Hornák")
+                email.set("bence.hornak@gmail.com")
+            }
+        }
+        scm {
+            connection.set(
+                "scm:git:https://github.com/open-feature/kotlin-sdk-contrib.git"
+            )
+            developerConnection.set(
+                "scm:git:ssh://open-feature/kotlin-sdk-contrib.git"
+            )
+            url.set("https://github.com/open-feature/kotlin-sdk-contrib")
+        }
+    }
+}

--- a/hooks/logging-slf4j/README.md
+++ b/hooks/logging-slf4j/README.md
@@ -1,0 +1,50 @@
+# OpenFeature SLF4J Logger Adapter
+
+This module provides an adapter for SLF4J loggers to work with the OpenFeature Kotlin SDK's logging infrastructure.
+
+## Installation
+
+Add the dependency to your project:
+
+```kotlin
+dependencies {
+    implementation("dev.openfeature.kotlin.contrib.hooks:logging-slf4j:VERSION")
+}
+```
+
+## Usage
+
+Use the `Slf4jLoggerAdapter` to wrap your existing SLF4J logger:
+
+```kotlin
+import dev.openfeature.kotlin.contrib.hooks.logging.slf4j.Slf4jLoggerAdapter
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.hooks.LoggingHook
+
+// Create an SLF4J logger
+val slf4jLogger = org.slf4j.LoggerFactory.getLogger("FeatureFlags")
+
+// Wrap it with the adapter
+val logger = Slf4jLoggerAdapter(slf4jLogger)
+
+// Use with OpenFeature logging hook
+OpenFeatureAPI.addHooks(listOf(LoggingHook<Any>(logger = logger)))
+```
+
+### Convenience Factory Method
+
+You can also use the convenience factory method:
+
+```kotlin
+val logger = Slf4jLoggerAdapter.getLogger("FeatureFlags")
+OpenFeatureAPI.addHooks(listOf(LoggingHook<Any>(logger = logger)))
+```
+
+## Requirements
+
+- JVM target: Java 11+
+- SLF4J API: 2.0.9 or compatible version
+
+## License
+
+Apache 2.0

--- a/hooks/logging-slf4j/build.gradle.kts
+++ b/hooks/logging-slf4j/build.gradle.kts
@@ -1,0 +1,37 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("dev.openfeature.hook-conventions")
+}
+
+kotlin {
+    jvm {
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.JVM_11)
+                }
+            }
+        }
+    }
+
+    sourceSets {
+        jvmMain.dependencies {
+            api(libs.openfeature.kotlin.sdk)
+            compileOnly("org.slf4j:slf4j-api:2.0.9")
+        }
+        jvmTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation("org.slf4j:slf4j-simple:2.0.9")
+        }
+    }
+}
+
+mavenPublishing {
+    pom {
+        name.set("OpenFeature SLF4J Logger Adapter")
+        description.set(
+            "SLF4J adapter for the OpenFeature Kotlin SDK. Allows developers to use their existing SLF4J setup with OpenFeature.",
+        )
+    }
+}

--- a/hooks/logging-slf4j/src/jvmMain/kotlin/dev/openfeature/kotlin/contrib/hooks/logging/slf4j/Slf4jLoggerAdapter.kt
+++ b/hooks/logging-slf4j/src/jvmMain/kotlin/dev/openfeature/kotlin/contrib/hooks/logging/slf4j/Slf4jLoggerAdapter.kt
@@ -1,0 +1,58 @@
+package dev.openfeature.kotlin.contrib.hooks.logging.slf4j
+
+import dev.openfeature.kotlin.sdk.logging.Logger
+import org.slf4j.Logger as Slf4jLoggerInterface
+
+/**
+ * Adapter for SLF4J loggers. This allows developers to use their existing
+ * SLF4J setup without implementing the Logger interface.
+ *
+ * Example usage:
+ * ```kotlin
+ * val slf4jLogger = org.slf4j.LoggerFactory.getLogger("FeatureFlags")
+ * val logger = Slf4jLoggerAdapter(slf4jLogger)
+ * OpenFeatureAPI.addHooks(listOf(LoggingHook<Any>(logger = logger)))
+ * ```
+ */
+class Slf4jLoggerAdapter(private val slf4jLogger: Slf4jLoggerInterface) : Logger {
+    override fun debug(message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            slf4jLogger.debug(message, throwable)
+        } else {
+            slf4jLogger.debug(message)
+        }
+    }
+
+    override fun info(message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            slf4jLogger.info(message, throwable)
+        } else {
+            slf4jLogger.info(message)
+        }
+    }
+
+    override fun warn(message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            slf4jLogger.warn(message, throwable)
+        } else {
+            slf4jLogger.warn(message)
+        }
+    }
+
+    override fun error(message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            slf4jLogger.error(message, throwable)
+        } else {
+            slf4jLogger.error(message)
+        }
+    }
+
+    companion object {
+        /**
+         * Convenience factory method to create a logger from a logger name.
+         */
+        fun getLogger(name: String): Logger {
+            return Slf4jLoggerAdapter(org.slf4j.LoggerFactory.getLogger(name))
+        }
+    }
+}

--- a/hooks/logging-timber/README.md
+++ b/hooks/logging-timber/README.md
@@ -1,0 +1,42 @@
+# OpenFeature Timber Logger Adapter
+
+This module provides an adapter for Timber loggers to work with the OpenFeature Kotlin SDK's logging infrastructure on Android.
+
+## Installation
+
+Add the dependency to your project:
+
+```kotlin
+dependencies {
+    implementation("dev.openfeature.kotlin.contrib.hooks:logging-timber:VERSION")
+}
+```
+
+## Usage
+
+Use the `TimberLoggerAdapter` to integrate Timber with OpenFeature:
+
+```kotlin
+import dev.openfeature.kotlin.contrib.hooks.logging.timber.TimberLoggerAdapter
+import dev.openfeature.kotlin.sdk.OpenFeatureAPI
+import dev.openfeature.kotlin.sdk.hooks.LoggingHook
+import timber.log.Timber
+
+// Set up Timber (typically done in Application.onCreate())
+Timber.plant(Timber.DebugTree())
+
+// Create the adapter
+val logger = TimberLoggerAdapter()
+
+// Use with OpenFeature logging hook
+OpenFeatureAPI.addHooks(listOf(LoggingHook<Any>(logger = logger)))
+```
+
+## Requirements
+
+- Android SDK: API 21+
+- Timber: 5.0.1 or compatible version
+
+## License
+
+Apache 2.0

--- a/hooks/logging-timber/build.gradle.kts
+++ b/hooks/logging-timber/build.gradle.kts
@@ -1,0 +1,54 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("dev.openfeature.hook-conventions")
+    id("com.android.library")
+}
+
+kotlin {
+    androidTarget {
+        publishLibraryVariants("release")
+
+        compilations.all {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.JVM_11)
+                }
+            }
+        }
+    }
+
+    sourceSets {
+        androidMain.dependencies {
+            api(libs.openfeature.kotlin.sdk)
+            compileOnly("com.jakewharton.timber:timber:5.0.1")
+        }
+        androidUnitTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation("com.jakewharton.timber:timber:5.0.1")
+        }
+    }
+}
+
+android {
+    namespace = "dev.openfeature.kotlin.contrib.hooks.logging.timber"
+    compileSdk = 33
+
+    defaultConfig {
+        minSdk = 21
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+}
+
+mavenPublishing {
+    pom {
+        name.set("OpenFeature Timber Logger Adapter")
+        description.set(
+            "Timber adapter for the OpenFeature Kotlin SDK. Allows developers to use their existing Timber setup with OpenFeature on Android.",
+        )
+    }
+}

--- a/hooks/logging-timber/src/androidMain/kotlin/dev/openfeature/kotlin/contrib/hooks/logging/timber/TimberLoggerAdapter.kt
+++ b/hooks/logging-timber/src/androidMain/kotlin/dev/openfeature/kotlin/contrib/hooks/logging/timber/TimberLoggerAdapter.kt
@@ -1,0 +1,49 @@
+package dev.openfeature.kotlin.contrib.hooks.logging.timber
+
+import dev.openfeature.kotlin.sdk.logging.Logger
+import timber.log.Timber
+
+/**
+ * Adapter for Timber (popular Android logging library).
+ * Allows developers to use their existing Timber setup.
+ *
+ * Example usage:
+ * ```kotlin
+ * Timber.plant(Timber.DebugTree())
+ * val logger = TimberLoggerAdapter()
+ * OpenFeatureAPI.addHooks(listOf(LoggingHook<Any>(logger = logger)))
+ * ```
+ */
+class TimberLoggerAdapter : Logger {
+    override fun debug(message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            Timber.d(throwable, message)
+        } else {
+            Timber.d(message)
+        }
+    }
+
+    override fun info(message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            Timber.i(throwable, message)
+        } else {
+            Timber.i(message)
+        }
+    }
+
+    override fun warn(message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            Timber.w(throwable, message)
+        } else {
+            Timber.w(message)
+        }
+    }
+
+    override fun error(message: String, throwable: Throwable?) {
+        if (throwable != null) {
+            Timber.e(throwable, message)
+        } else {
+            Timber.e(message)
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,3 +18,6 @@ dependencyResolutionManagement {
 
 include(":providers:env-var")
 include(":providers:ofrep")
+
+include(":hooks:logging-slf4j")
+include(":hooks:logging-timber")


### PR DESCRIPTION
## Intent

Add logging framework adapters for SLF4J (JVM) and Timber (Android) as opt-in contrib modules.

## Motivation

Following architectural feedback on [kotlin-sdk#218](https://github.com/open-feature/kotlin-sdk/pull/218), we're keeping the core SDK free from opinionated dependencies by moving framework-specific logging adapters to contrib.

This allows developers who use SLF4J or Timber to integrate with OpenFeature's logging infrastructure without forcing these dependencies on all users.

## Changes

### New Modules

**hooks/logging-slf4j** (JVM only)
- `Slf4jLoggerAdapter` - Bridges OpenFeature Logger to SLF4J
- Works with any SLF4J implementation (Logback, Log4j2, etc.)
- Preserves throwable stack traces and log levels
- Includes convenience factory method: `Slf4jLoggerAdapter.getLogger(name)`

**hooks/logging-timber** (Android only)
- `TimberLoggerAdapter` - Bridges OpenFeature Logger to Timber
- Integrates with Timber's tree system
- Works with custom Timber implementations
- Minimal overhead wrapper

### Build Infrastructure

- Created `dev.openfeature.hook-conventions.gradle.kts` plugin for hook modules
- Updated `settings.gradle.kts` to include new hook modules
- Dependencies are `compileOnly` - users provide their own implementations

### Dependencies

```kotlin
// hooks/logging-slf4j
compileOnly("org.slf4j:slf4j-api:2.0.9")

// hooks/logging-timber
compileOnly("com.jakewharton.timber:timber:5.0.1")
```

## Usage

### SLF4J Adapter

```kotlin
dependencies {
    implementation("dev.openfeature.kotlin.contrib.hooks:logging-slf4j:VERSION")
}
```

```kotlin
val slf4jLogger = org.slf4j.LoggerFactory.getLogger("FeatureFlags")
val logger = Slf4jLoggerAdapter(slf4jLogger)
OpenFeatureAPI.addHooks(listOf(LoggingHook<Any>(logger = logger)))

// Or use convenience method
val logger = Slf4jLoggerAdapter.getLogger("FeatureFlags")
```

### Timber Adapter

```kotlin
dependencies {
    implementation("dev.openfeature.kotlin.contrib.hooks:logging-timber:VERSION")
}
```

```kotlin
Timber.plant(Timber.DebugTree())
val logger = TimberLoggerAdapter()
OpenFeatureAPI.addHooks(listOf(LoggingHook<Any>(logger = logger)))
```

## Testing

- ✅ Builds successfully with Gradle 9.0
- ✅ Follows existing contrib module patterns
- ✅ API documentation included in KDoc
- ✅ README files with usage examples

## Related

- Addresses feedback from @bencehornak on kotlin-sdk#218
- Requires kotlin-sdk#217 (core logging infrastructure) to be merged first
- Part of logging infrastructure initiative

## Breaking Changes

None - these are new opt-in modules.