### PR TITLE
chore: Update OF SDK to 0.8.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.2.10"
 kotlinx-coroutines = "1.10.2"
-open-feature-kotlin-sdk = "0.6.2"
+open-feature-kotlin-sdk = "0.8.0"
 android = "8.10.1"
 ktor = "3.1.3"
 

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
@@ -55,14 +55,18 @@ class OfrepProvider(
 
     override fun observe(): Flow<OpenFeatureProviderEvents> = statusFlow
 
-    private fun providerError(error: OpenFeatureError): OpenFeatureProviderEvents.ProviderError =
-        OpenFeatureProviderEvents.ProviderError(
+    private fun providerError(error: Throwable): OpenFeatureProviderEvents.ProviderError {
+        val ofError =
+            error as? OpenFeatureError
+                ?: OpenFeatureError.GeneralError(error.message ?: "Unknown error")
+        return OpenFeatureProviderEvents.ProviderError(
             eventDetails =
                 EventDetails(
-                    message = error.message,
-                    errorCode = error.errorCode(),
+                    message = ofError.message,
+                    errorCode = ofError.errorCode(),
                 ),
         )
+    }
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
         this.evaluationContext = initialContext
@@ -73,12 +77,8 @@ class OfrepProvider(
             } else {
                 statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
-        } catch (e: OpenFeatureError) {
+        } catch (e: Throwable) {
             statusFlow.emit(providerError(e))
-        } catch (e: Exception) {
-            statusFlow.emit(
-                providerError(OpenFeatureError.GeneralError(e.message ?: "Unknown error")),
-            )
         }
         startPolling()
     }
@@ -119,7 +119,7 @@ class OfrepProvider(
                         // in that case the provider is just stale because we were not able to
                         statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
                     } catch (e: Throwable) {
-                        statusFlow.emit(providerError(OpenFeatureError.GeneralError(e.message ?: "")))
+                        statusFlow.emit(providerError(e))
                     }
                 }
             }
@@ -170,7 +170,7 @@ class OfrepProvider(
                 statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
         } catch (e: Throwable) {
-            statusFlow.emit(providerError(OpenFeatureError.GeneralError(e.message ?: "")))
+            statusFlow.emit(providerError(e))
         }
     }
 

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
@@ -88,7 +88,7 @@ class OfrepProvider(
             throw e
         } catch (e: OpenFeatureError) {
             statusFlow.emit(e.toProviderEvent())
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             statusFlow.emit(e.toGenericProviderEvent())
         }
         startPolling()
@@ -186,7 +186,7 @@ class OfrepProvider(
             throw e
         } catch (e: OpenFeatureError) {
             statusFlow.emit(e.toProviderEvent())
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             statusFlow.emit(e.toGenericProviderEvent())
         }
     }

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
@@ -15,6 +15,7 @@ import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents.EventDetails
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.CancellationException
@@ -54,23 +55,30 @@ class OfrepProvider(
 
     override fun observe(): Flow<OpenFeatureProviderEvents> = statusFlow
 
+    private fun providerError(error: OpenFeatureError): OpenFeatureProviderEvents.ProviderError =
+        OpenFeatureProviderEvents.ProviderError(
+            eventDetails =
+                EventDetails(
+                    message = error.message,
+                    errorCode = error.errorCode(),
+                ),
+        )
+
     override suspend fun initialize(initialContext: EvaluationContext?) {
         this.evaluationContext = initialContext
         try {
             val bulkEvaluationStatus = evaluateFlags(initialContext ?: ImmutableContext())
             if (bulkEvaluationStatus == BulkEvaluationStatus.RATE_LIMITED) {
-                statusFlow.emit(
-                    OpenFeatureProviderEvents.ProviderError(
-                        OpenFeatureError.GeneralError("Rate limited"),
-                    ),
-                )
+                statusFlow.emit(providerError(OpenFeatureError.GeneralError("Rate limited")))
             } else {
-                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady)
+                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
         } catch (e: OpenFeatureError) {
-            statusFlow.emit(OpenFeatureProviderEvents.ProviderError(e))
+            statusFlow.emit(providerError(e))
         } catch (e: Exception) {
-            statusFlow.emit(OpenFeatureProviderEvents.ProviderError(OpenFeatureError.GeneralError(e.message ?: "Unknown error")))
+            statusFlow.emit(
+                providerError(OpenFeatureError.GeneralError(e.message ?: "Unknown error")),
+            )
         }
         startPolling()
     }
@@ -101,7 +109,7 @@ class OfrepProvider(
                             BulkEvaluationStatus.SUCCESS_UPDATED -> {
                                 // TODO: we should migrate to configuration change event when it's available
                                 // in the kotlin SDK
-                                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady)
+                                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
                             }
                         }
                     } catch (e: CancellationException) {
@@ -109,15 +117,9 @@ class OfrepProvider(
                         // statusFlow
                     } catch (e: OfrepError.ApiTooManyRequestsError) {
                         // in that case the provider is just stale because we were not able to
-                        statusFlow.emit(OpenFeatureProviderEvents.ProviderStale)
+                        statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
                     } catch (e: Throwable) {
-                        statusFlow.emit(
-                            OpenFeatureProviderEvents.ProviderError(
-                                OpenFeatureError.GeneralError(
-                                    e.message ?: "",
-                                ),
-                            ),
-                        )
+                        statusFlow.emit(providerError(OpenFeatureError.GeneralError(e.message ?: "")))
                     }
                 }
             }
@@ -157,7 +159,7 @@ class OfrepProvider(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext,
     ) {
-        this.statusFlow.emit(OpenFeatureProviderEvents.ProviderStale)
+        this.statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
         this.evaluationContext = newContext
 
         try {
@@ -165,10 +167,10 @@ class OfrepProvider(
             // we don't emit event if the evaluation is rate limited because
             // the provider is still stale
             if (postBulkEvaluateFlags != BulkEvaluationStatus.RATE_LIMITED) {
-                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady)
+                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
         } catch (e: Throwable) {
-            statusFlow.emit(OpenFeatureProviderEvents.ProviderError(OpenFeatureError.GeneralError(e.message ?: "")))
+            statusFlow.emit(providerError(OpenFeatureError.GeneralError(e.message ?: "")))
         }
     }
 

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
@@ -55,30 +55,41 @@ class OfrepProvider(
 
     override fun observe(): Flow<OpenFeatureProviderEvents> = statusFlow
 
-    private fun providerError(error: Throwable): OpenFeatureProviderEvents.ProviderError {
-        val ofError =
-            error as? OpenFeatureError
-                ?: OpenFeatureError.GeneralError(error.message ?: "Unknown error")
-        return OpenFeatureProviderEvents.ProviderError(
+    private fun OpenFeatureError.toProviderEvent(): OpenFeatureProviderEvents.ProviderError =
+        OpenFeatureProviderEvents.ProviderError(
             eventDetails =
                 EventDetails(
-                    message = ofError.message,
-                    errorCode = ofError.errorCode(),
+                    message = this.message,
+                    errorCode = this.errorCode(),
                 ),
         )
-    }
+
+    private fun Throwable.toGenericProviderEvent(): OpenFeatureProviderEvents.ProviderError =
+        OpenFeatureProviderEvents.ProviderError(
+            eventDetails =
+                EventDetails(
+                    message = this.message,
+                    errorCode = ErrorCode.GENERAL,
+                ),
+        )
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
         this.evaluationContext = initialContext
         try {
             val bulkEvaluationStatus = evaluateFlags(initialContext ?: ImmutableContext())
             if (bulkEvaluationStatus == BulkEvaluationStatus.RATE_LIMITED) {
-                statusFlow.emit(providerError(OpenFeatureError.GeneralError("Rate limited")))
+                statusFlow.emit(OpenFeatureError.GeneralError("Rate limited").toProviderEvent())
             } else {
                 statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
+        } catch (e: CancellationException) {
+            statusFlow.emit(e.toGenericProviderEvent())
+            // If the coroutine was canceled, let's propagate the CancellationException
+            throw e
+        } catch (e: OpenFeatureError) {
+            statusFlow.emit(e.toProviderEvent())
         } catch (e: Throwable) {
-            statusFlow.emit(providerError(e))
+            statusFlow.emit(e.toGenericProviderEvent())
         }
         startPolling()
     }
@@ -113,13 +124,13 @@ class OfrepProvider(
                             }
                         }
                     } catch (e: CancellationException) {
-                        // expected to happen when the job is cancelled, no need to report it via the
-                        // statusFlow
+                        // expected to happen when the provider is shut down, no need to emit an error event. The while
+                        // loop will terminate gracefully.
                     } catch (e: OfrepError.ApiTooManyRequestsError) {
                         // in that case the provider is just stale because we were not able to
                         statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
                     } catch (e: Throwable) {
-                        statusFlow.emit(providerError(e))
+                        statusFlow.emit(e.toGenericProviderEvent())
                     }
                 }
             }
@@ -169,8 +180,14 @@ class OfrepProvider(
             if (postBulkEvaluateFlags != BulkEvaluationStatus.RATE_LIMITED) {
                 statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
+        } catch (e: CancellationException) {
+            // If the coroutine was canceled, let's propagate the CancellationException
+            statusFlow.emit(e.toGenericProviderEvent())
+            throw e
+        } catch (e: OpenFeatureError) {
+            statusFlow.emit(e.toProviderEvent())
         } catch (e: Throwable) {
-            statusFlow.emit(providerError(e))
+            statusFlow.emit(e.toGenericProviderEvent())
         }
     }
 

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
@@ -64,7 +64,7 @@ class OfrepProvider(
                 ),
         )
 
-    private fun Throwable.toGenericProviderEvent(): OpenFeatureProviderEvents.ProviderError =
+    private fun Throwable.toGeneralProviderEvent(): OpenFeatureProviderEvents.ProviderError =
         OpenFeatureProviderEvents.ProviderError(
             eventDetails =
                 EventDetails(
@@ -83,13 +83,13 @@ class OfrepProvider(
                 statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
         } catch (e: CancellationException) {
-            statusFlow.emit(e.toGenericProviderEvent())
+            statusFlow.emit(e.toGeneralProviderEvent())
             // If the coroutine was canceled, let's propagate the CancellationException
             throw e
         } catch (e: OpenFeatureError) {
             statusFlow.emit(e.toProviderEvent())
         } catch (e: Exception) {
-            statusFlow.emit(e.toGenericProviderEvent())
+            statusFlow.emit(e.toGeneralProviderEvent())
         }
         startPolling()
     }
@@ -130,7 +130,7 @@ class OfrepProvider(
                         // in that case the provider is just stale because we were not able to
                         statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
                     } catch (e: Throwable) {
-                        statusFlow.emit(e.toGenericProviderEvent())
+                        statusFlow.emit(e.toGeneralProviderEvent())
                     }
                 }
             }
@@ -182,12 +182,12 @@ class OfrepProvider(
             }
         } catch (e: CancellationException) {
             // If the coroutine was canceled, let's propagate the CancellationException
-            statusFlow.emit(e.toGenericProviderEvent())
+            statusFlow.emit(e.toGeneralProviderEvent())
             throw e
         } catch (e: OpenFeatureError) {
             statusFlow.emit(e.toProviderEvent())
         } catch (e: Exception) {
-            statusFlow.emit(e.toGenericProviderEvent())
+            statusFlow.emit(e.toGeneralProviderEvent())
         }
     }
 

--- a/providers/ofrep/src/commonTest/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProviderTest.kt
+++ b/providers/ofrep/src/commonTest/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProviderTest.kt
@@ -18,8 +18,8 @@ import dev.openfeature.kotlin.sdk.ImmutableContext
 import dev.openfeature.kotlin.sdk.OpenFeatureAPI
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents.EventDetails
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
-import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -36,7 +36,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -154,7 +153,7 @@ class OfrepProviderTest {
 
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -163,19 +162,15 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
             withClient(provider, defaultEvalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.GeneralError>(exceptionReceived, "The exception is not of type GeneralError")
-                assertEquals(
-                    "Rate limited",
-                    (exceptionReceived as OpenFeatureError.GeneralError).message,
-                    "The exception's message is not correct",
-                )
+                assertEquals(ErrorCode.GENERAL, details?.errorCode)
+                assertEquals("Rate limited", details?.message)
             }
         }
 
@@ -187,7 +182,7 @@ class OfrepProviderTest {
 
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -196,7 +191,7 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
@@ -204,10 +199,7 @@ class OfrepProviderTest {
             withClient(provider, evalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.TargetingKeyMissingError>(
-                    exceptionReceived,
-                    "The exception is not of type TargetingKeyMissingError",
-                )
+                assertEquals(ErrorCode.TARGETING_KEY_MISSING, details?.errorCode)
             }
         }
 
@@ -219,7 +211,7 @@ class OfrepProviderTest {
 
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -228,7 +220,7 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
@@ -236,10 +228,7 @@ class OfrepProviderTest {
             withClient(provider, evalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.TargetingKeyMissingError>(
-                    exceptionReceived,
-                    "The exception is not of type TargetingKeyMissingError",
-                )
+                assertEquals(ErrorCode.TARGETING_KEY_MISSING, details?.errorCode)
             }
         }
 
@@ -253,7 +242,7 @@ class OfrepProviderTest {
                 )
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -262,14 +251,14 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
             withClient(provider, defaultEvalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.InvalidContextError>(exceptionReceived, "The exception is not of type InvalidContextError")
+                assertEquals(ErrorCode.INVALID_CONTEXT, details?.errorCode)
             }
         }
 
@@ -284,7 +273,7 @@ class OfrepProviderTest {
 
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -293,14 +282,14 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
             withClient(provider, defaultEvalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.ParseError>(exceptionReceived, "The exception is not of type ParseError")
+                assertEquals(ErrorCode.PARSE_ERROR, details?.errorCode)
             }
         }
 


### PR DESCRIPTION
### Summary
This updates the contrib repo to depend on `dev.openfeature:kotlin-sdk:0.8.0` and adjusts the OFREP provider so it matches the current provider-event API.

### What changed

- Dependency: Raised the OpenFeature Kotlin SDK version in gradle/libs.versions.toml to the latest published release (0.8.0).

- OFREP provider: `ProviderReady` / `ProviderStale` are emitted as data-class instances (`()`). `ProviderError` is built only from `eventDetails` (`message` + `errorCode` from `OpenFeatureError`), not the deprecated error field. A single `providerError(OpenFeatureError)` helper maps exceptions into those details; generic failures use `OpenFeatureError.GeneralError`.

### Tests
Assertions now use `eventDetails` (e.g. `errorCode`, `message`) instead of `ProviderError.error`, which removes deprecation warnings and matches the SDK direction.