### PR TITLE
chore: Update FeatureProvider to SMP

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         google()
-        mavenLocal()
         mavenCentral()
         gradlePluginPortal()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.2.10"
 kotlinx-coroutines = "1.10.2"
-open-feature-kotlin-sdk = "0.6.2"
+open-feature-kotlin-sdk = "0.8.0"
 android = "8.10.1"
 ktor = "3.1.3"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.2.10"
 kotlinx-coroutines = "1.10.2"
 open-feature-kotlin-sdk = "0.8.0"
-android = "8.10.1"
+android = "8.13.0"
 ktor = "3.1.3"
 
 [libraries]

--- a/providers/env-var/api/env-var.api
+++ b/providers/env-var/api/env-var.api
@@ -1,4 +1,4 @@
-public final class dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
+public final class dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider : dev/openfeature/kotlin/sdk/StateManagingProvider {
 	public static final field Companion Ldev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider$Companion;
 	public fun <init> ()V
 	public fun <init> (Ldev/openfeature/kotlin/contrib/providers/envvar/EnvironmentGateway;Ldev/openfeature/kotlin/contrib/providers/envvar/EnvironmentKeyTransformer;)V
@@ -7,8 +7,10 @@ public final class dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvide
 	public fun getDoubleEvaluation (Ljava/lang/String;DLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getHooks ()Ljava/util/List;
 	public fun getIntegerEvaluation (Ljava/lang/String;ILdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getLongEvaluation (Ljava/lang/String;JLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStatus ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;

--- a/providers/env-var/build.gradle.kts
+++ b/providers/env-var/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             api(libs.openfeature.kotlin.sdk)
+            api(libs.kotlinx.coroutines.core)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/providers/env-var/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider.kt
+++ b/providers/env-var/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/envvar/EnvVarProvider.kt
@@ -1,37 +1,58 @@
 package dev.openfeature.kotlin.contrib.providers.envvar
 
 import dev.openfeature.kotlin.sdk.EvaluationContext
-import dev.openfeature.kotlin.sdk.FeatureProvider
 import dev.openfeature.kotlin.sdk.Hook
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
 import dev.openfeature.kotlin.sdk.Reason
+import dev.openfeature.kotlin.sdk.StateManagingProvider
 import dev.openfeature.kotlin.sdk.Value
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.yield
 
 /** EnvVarProvider is the Kotlin provider implementation for the environment variables.  */
 class EnvVarProvider(
     private val environmentGateway: EnvironmentGateway = platformSpecificEnvironmentGateway(),
     private val keyTransformer: EnvironmentKeyTransformer = EnvironmentKeyTransformer.doNothing(),
-) : FeatureProvider {
+) : StateManagingProvider {
+    private val statusTracker = ProviderStatusTracker()
+
     override val hooks: List<Hook<*>> = emptyList()
     override val metadata: ProviderMetadata
         get() = Metadata
 
+    override val status: StateFlow<OpenFeatureStatus> = statusTracker.status
+
     override suspend fun initialize(initialContext: EvaluationContext?) {
-        // Nothing to do here
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
     }
 
     override fun shutdown() {
-        // Nothing to do here
+        statusTracker.send(
+            OpenFeatureProviderEvents.ProviderError(
+                OpenFeatureProviderEvents.EventDetails(
+                    message = "Environment Variables provider shut down; not ready for evaluation",
+                    errorCode = ErrorCode.PROVIDER_NOT_READY,
+                ),
+            ),
+        )
     }
 
     override suspend fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext,
     ) {
-        // Nothing to do here
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReconciling())
+        yield()
+        statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
     }
+
+    override fun observe() = statusTracker.observe()
 
     override fun getBooleanEvaluation(
         key: String,
@@ -50,6 +71,12 @@ class EnvVarProvider(
         defaultValue: Int,
         context: EvaluationContext?,
     ): ProviderEvaluation<Int> = evaluateEnvironmentVariable(key, String::toInt)
+
+    override fun getLongEvaluation(
+        key: String,
+        defaultValue: Long,
+        context: EvaluationContext?,
+    ): ProviderEvaluation<Long> = evaluateEnvironmentVariable(key, String::toLong)
 
     override fun getStringEvaluation(
         key: String,

--- a/providers/ofrep/api/android/ofrep.api
+++ b/providers/ofrep/api/android/ofrep.api
@@ -1,11 +1,13 @@
-public final class dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
+public final class dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider : dev/openfeature/kotlin/sdk/StateManagingProvider {
 	public fun <init> (Ldev/openfeature/kotlin/contrib/providers/ofrep/bean/OfrepOptions;)V
 	public fun getBooleanEvaluation (Ljava/lang/String;ZLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getDoubleEvaluation (Ljava/lang/String;DLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getHooks ()Ljava/util/List;
 	public fun getIntegerEvaluation (Ljava/lang/String;ILdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getLongEvaluation (Ljava/lang/String;JLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStatus ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;

--- a/providers/ofrep/api/jvm/ofrep.api
+++ b/providers/ofrep/api/jvm/ofrep.api
@@ -1,11 +1,13 @@
-public final class dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider : dev/openfeature/kotlin/sdk/FeatureProvider {
+public final class dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider : dev/openfeature/kotlin/sdk/StateManagingProvider {
 	public fun <init> (Ldev/openfeature/kotlin/contrib/providers/ofrep/bean/OfrepOptions;)V
 	public fun getBooleanEvaluation (Ljava/lang/String;ZLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getDoubleEvaluation (Ljava/lang/String;DLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getHooks ()Ljava/util/List;
 	public fun getIntegerEvaluation (Ljava/lang/String;ILdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getLongEvaluation (Ljava/lang/String;JLdev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun getMetadata ()Ldev/openfeature/kotlin/sdk/ProviderMetadata;
 	public fun getObjectEvaluation (Ljava/lang/String;Ldev/openfeature/kotlin/sdk/Value;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
+	public fun getStatus ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getStringEvaluation (Ljava/lang/String;Ljava/lang/String;Ldev/openfeature/kotlin/sdk/EvaluationContext;)Ldev/openfeature/kotlin/sdk/ProviderEvaluation;
 	public fun initialize (Ldev/openfeature/kotlin/sdk/EvaluationContext;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun observe ()Lkotlinx/coroutines/flow/Flow;

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
@@ -55,14 +55,18 @@ class OfrepProvider(
 
     override fun observe(): Flow<OpenFeatureProviderEvents> = statusFlow
 
-    private fun providerError(error: OpenFeatureError): OpenFeatureProviderEvents.ProviderError =
-        OpenFeatureProviderEvents.ProviderError(
+    private fun providerError(error: Throwable): OpenFeatureProviderEvents.ProviderError {
+        val ofError =
+            error as? OpenFeatureError
+                ?: OpenFeatureError.GeneralError(error.message ?: "Unknown error")
+        return OpenFeatureProviderEvents.ProviderError(
             eventDetails =
                 EventDetails(
-                    message = error.message,
-                    errorCode = error.errorCode(),
+                    message = ofError.message,
+                    errorCode = ofError.errorCode(),
                 ),
         )
+    }
 
     override suspend fun initialize(initialContext: EvaluationContext?) {
         this.evaluationContext = initialContext
@@ -73,12 +77,8 @@ class OfrepProvider(
             } else {
                 statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
-        } catch (e: OpenFeatureError) {
+        } catch (e: Throwable) {
             statusFlow.emit(providerError(e))
-        } catch (e: Exception) {
-            statusFlow.emit(
-                providerError(OpenFeatureError.GeneralError(e.message ?: "Unknown error")),
-            )
         }
         startPolling()
     }
@@ -119,7 +119,7 @@ class OfrepProvider(
                         // in that case the provider is just stale because we were not able to
                         statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
                     } catch (e: Throwable) {
-                        statusFlow.emit(providerError(OpenFeatureError.GeneralError(e.message ?: "")))
+                        statusFlow.emit(providerError(e))
                     }
                 }
             }
@@ -170,7 +170,7 @@ class OfrepProvider(
                 statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
         } catch (e: Throwable) {
-            statusFlow.emit(providerError(OpenFeatureError.GeneralError(e.message ?: "")))
+            statusFlow.emit(providerError(e))
         }
     }
 

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
@@ -15,6 +15,7 @@ import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents.EventDetails
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
 import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import kotlinx.coroutines.CancellationException
@@ -54,23 +55,30 @@ class OfrepProvider(
 
     override fun observe(): Flow<OpenFeatureProviderEvents> = statusFlow
 
+    private fun providerError(error: OpenFeatureError): OpenFeatureProviderEvents.ProviderError =
+        OpenFeatureProviderEvents.ProviderError(
+            eventDetails =
+                EventDetails(
+                    message = error.message,
+                    errorCode = error.errorCode(),
+                ),
+        )
+
     override suspend fun initialize(initialContext: EvaluationContext?) {
         this.evaluationContext = initialContext
         try {
             val bulkEvaluationStatus = evaluateFlags(initialContext ?: ImmutableContext())
             if (bulkEvaluationStatus == BulkEvaluationStatus.RATE_LIMITED) {
-                statusFlow.emit(
-                    OpenFeatureProviderEvents.ProviderError(
-                        OpenFeatureError.GeneralError("Rate limited"),
-                    ),
-                )
+                statusFlow.emit(providerError(OpenFeatureError.GeneralError("Rate limited")))
             } else {
-                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady)
+                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
         } catch (e: OpenFeatureError) {
-            statusFlow.emit(OpenFeatureProviderEvents.ProviderError(e))
+            statusFlow.emit(providerError(e))
         } catch (e: Exception) {
-            statusFlow.emit(OpenFeatureProviderEvents.ProviderError(OpenFeatureError.GeneralError(e.message ?: "Unknown error")))
+            statusFlow.emit(
+                providerError(OpenFeatureError.GeneralError(e.message ?: "Unknown error")),
+            )
         }
         startPolling()
     }
@@ -101,7 +109,7 @@ class OfrepProvider(
                             BulkEvaluationStatus.SUCCESS_UPDATED -> {
                                 // TODO: we should migrate to configuration change event when it's available
                                 // in the kotlin SDK
-                                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady)
+                                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
                             }
                         }
                     } catch (e: CancellationException) {
@@ -109,15 +117,9 @@ class OfrepProvider(
                         // statusFlow
                     } catch (e: OfrepError.ApiTooManyRequestsError) {
                         // in that case the provider is just stale because we were not able to
-                        statusFlow.emit(OpenFeatureProviderEvents.ProviderStale)
+                        statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
                     } catch (e: Throwable) {
-                        statusFlow.emit(
-                            OpenFeatureProviderEvents.ProviderError(
-                                OpenFeatureError.GeneralError(
-                                    e.message ?: "",
-                                ),
-                            ),
-                        )
+                        statusFlow.emit(providerError(OpenFeatureError.GeneralError(e.message ?: "")))
                     }
                 }
             }
@@ -157,7 +159,7 @@ class OfrepProvider(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext,
     ) {
-        this.statusFlow.emit(OpenFeatureProviderEvents.ProviderStale)
+        this.statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
         this.evaluationContext = newContext
 
         try {
@@ -165,10 +167,10 @@ class OfrepProvider(
             // we don't emit event if the evaluation is rate limited because
             // the provider is still stale
             if (postBulkEvaluateFlags != BulkEvaluationStatus.RATE_LIMITED) {
-                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady)
+                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
             }
         } catch (e: Throwable) {
-            statusFlow.emit(OpenFeatureProviderEvents.ProviderError(OpenFeatureError.GeneralError(e.message ?: "")))
+            statusFlow.emit(providerError(OpenFeatureError.GeneralError(e.message ?: "")))
         }
     }
 

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProvider.kt
@@ -8,11 +8,13 @@ import dev.openfeature.kotlin.contrib.providers.ofrep.controller.OfrepApi
 import dev.openfeature.kotlin.contrib.providers.ofrep.enum.BulkEvaluationStatus
 import dev.openfeature.kotlin.contrib.providers.ofrep.error.OfrepError
 import dev.openfeature.kotlin.sdk.EvaluationContext
-import dev.openfeature.kotlin.sdk.FeatureProvider
 import dev.openfeature.kotlin.sdk.Hook
 import dev.openfeature.kotlin.sdk.ImmutableContext
+import dev.openfeature.kotlin.sdk.OpenFeatureStatus
 import dev.openfeature.kotlin.sdk.ProviderEvaluation
 import dev.openfeature.kotlin.sdk.ProviderMetadata
+import dev.openfeature.kotlin.sdk.ProviderStatusTracker
+import dev.openfeature.kotlin.sdk.StateManagingProvider
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents.EventDetails
@@ -23,7 +25,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlin.concurrent.Volatile
@@ -35,13 +37,17 @@ import kotlin.time.Instant
 @OptIn(ExperimentalTime::class)
 class OfrepProvider(
     private val ofrepOptions: OfrepOptions,
-) : FeatureProvider {
+) : StateManagingProvider {
     private val ofrepApi = OfrepApi(ofrepOptions)
     override val hooks: List<Hook<*>>
         get() = listOf()
 
     override val metadata: ProviderMetadata
         get() = OfrepProviderMetadata()
+
+    private val statusTracker = ProviderStatusTracker()
+
+    override val status: StateFlow<OpenFeatureStatus> = statusTracker.status
 
     private var evaluationContext: EvaluationContext? = null
 
@@ -51,9 +57,7 @@ class OfrepProvider(
     private val pollingScope: CoroutineScope = CoroutineScope(ofrepOptions.pollingDispatcher)
     private var pollingJob: Job? = null
 
-    private val statusFlow = MutableSharedFlow<OpenFeatureProviderEvents>(replay = 1)
-
-    override fun observe(): Flow<OpenFeatureProviderEvents> = statusFlow
+    override fun observe(): Flow<OpenFeatureProviderEvents> = statusTracker.observe()
 
     private fun providerError(error: Throwable): OpenFeatureProviderEvents.ProviderError {
         val ofError =
@@ -73,12 +77,12 @@ class OfrepProvider(
         try {
             val bulkEvaluationStatus = evaluateFlags(initialContext ?: ImmutableContext())
             if (bulkEvaluationStatus == BulkEvaluationStatus.RATE_LIMITED) {
-                statusFlow.emit(providerError(OpenFeatureError.GeneralError("Rate limited")))
+                statusTracker.send(providerError(OpenFeatureError.GeneralError("Rate limited")))
             } else {
-                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
+                statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
             }
         } catch (e: Throwable) {
-            statusFlow.emit(providerError(e))
+            statusTracker.send(providerError(e))
         }
         startPolling()
     }
@@ -109,17 +113,17 @@ class OfrepProvider(
                             BulkEvaluationStatus.SUCCESS_UPDATED -> {
                                 // TODO: we should migrate to configuration change event when it's available
                                 // in the kotlin SDK
-                                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
+                                statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
                             }
                         }
                     } catch (e: CancellationException) {
                         // expected to happen when the job is cancelled, no need to report it via the
-                        // statusFlow
+                        // status tracker
                     } catch (e: OfrepError.ApiTooManyRequestsError) {
                         // in that case the provider is just stale because we were not able to
-                        statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
+                        statusTracker.send(OpenFeatureProviderEvents.ProviderStale())
                     } catch (e: Throwable) {
-                        statusFlow.emit(providerError(e))
+                        statusTracker.send(providerError(e))
                     }
                 }
             }
@@ -143,6 +147,12 @@ class OfrepProvider(
         context: EvaluationContext?,
     ): ProviderEvaluation<Int> = genericEvaluation(key, defaultValue)
 
+    override fun getLongEvaluation(
+        key: String,
+        defaultValue: Long,
+        context: EvaluationContext?,
+    ): ProviderEvaluation<Long> = genericEvaluation(key, defaultValue)
+
     override fun getObjectEvaluation(
         key: String,
         defaultValue: Value,
@@ -159,7 +169,7 @@ class OfrepProvider(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext,
     ) {
-        this.statusFlow.emit(OpenFeatureProviderEvents.ProviderStale())
+        statusTracker.send(OpenFeatureProviderEvents.ProviderStale())
         this.evaluationContext = newContext
 
         try {
@@ -167,15 +177,23 @@ class OfrepProvider(
             // we don't emit event if the evaluation is rate limited because
             // the provider is still stale
             if (postBulkEvaluateFlags != BulkEvaluationStatus.RATE_LIMITED) {
-                statusFlow.emit(OpenFeatureProviderEvents.ProviderReady())
+                statusTracker.send(OpenFeatureProviderEvents.ProviderReady())
             }
         } catch (e: Throwable) {
-            statusFlow.emit(providerError(e))
+            statusTracker.send(providerError(e))
         }
     }
 
     override fun shutdown() {
         pollingJob?.cancel()
+        statusTracker.send(
+            OpenFeatureProviderEvents.ProviderError(
+                EventDetails(
+                    message = "OFREP provider shut down; not ready for evaluation",
+                    errorCode = ErrorCode.PROVIDER_NOT_READY,
+                ),
+            ),
+        )
     }
 
     private inline fun <reified T> genericEvaluation(

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/bean/OfrepApiResponse.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/bean/OfrepApiResponse.kt
@@ -42,6 +42,8 @@ inline fun <reified T> Value.toPrimitive(): T {
             Boolean::class -> asBoolean() as T?
             String::class -> asString() as T?
             Int::class -> asInteger() as T?
+            Long::class ->
+                (asLong() ?: asInteger()?.toLong()) as T?
             Double::class ->
                 // doubles might have been serialized as integers
                 (asDouble() ?: asInteger()?.toDouble()) as T?

--- a/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/serialization/ValueSerializer.kt
+++ b/providers/ofrep/src/commonMain/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/serialization/ValueSerializer.kt
@@ -67,6 +67,17 @@ internal object ValueSerializer : KSerializer<Value> {
         override fun deserialize(decoder: Decoder): Value.Integer = Value.Integer(decoder.decodeInt())
     }
 
+    private object LongValueSerializer : KSerializer<Value.Long> {
+        override val descriptor: SerialDescriptor = buildClassSerialDescriptor("dev.openfeature.kotlin.sdk.Value.Long")
+
+        override fun serialize(
+            encoder: Encoder,
+            value: Value.Long,
+        ) = encoder.encodeLong(value.long)
+
+        override fun deserialize(decoder: Decoder): Value.Long = Value.Long(decoder.decodeLong())
+    }
+
     @OptIn(ExperimentalTime::class)
     private object InstantValueSerializer : KSerializer<Value.Instant> {
         override val descriptor: SerialDescriptor = buildClassSerialDescriptor("dev.openfeature.kotlin.sdk.Value.Instant")
@@ -139,6 +150,7 @@ internal object ValueSerializer : KSerializer<Value> {
             is Value.Boolean -> encoder.encodeSerializableValue(BooleanValueSerializer, value)
             is Value.Double -> encoder.encodeSerializableValue(DoubleValueSerializer, value)
             is Value.Integer -> encoder.encodeSerializableValue(IntValueSerializer, value)
+            is Value.Long -> encoder.encodeSerializableValue(LongValueSerializer, value)
             is Value.Instant -> encoder.encodeSerializableValue(InstantValueSerializer, value)
             is Value.List -> encoder.encodeSerializableValue(ListValueSerializer, value)
             is Value.String -> encoder.encodeSerializableValue(StringValueSerializer, value)
@@ -160,19 +172,11 @@ internal object ValueSerializer : KSerializer<Value> {
                     // Order matters here: check for Int before Double to avoid loss of precision
                     // if a number is a whole number but represented as a double (e.g., 5.0)
                     element.longOrNull != null -> {
-                        // If it fits in Int, use IntValueSerializer, otherwise could be an issue
-                        // or you might need a Value.Long type. For now, assume it fits Int if it's an int.
-                        // This part might need refinement based on how you handle large integers.
-                        // If Value.Integer only holds Int, then a long might be an error or fallback to Double.
-                        // Let's assume for now that if it has no decimal, it could be an Int or a long that
-                        // should be treated as Int if it fits, or Double if it's too large for Int but fits Double.
                         val longVal = element.long
                         if (longVal >= Int.MIN_VALUE && longVal <= Int.MAX_VALUE) {
                             IntValueSerializer
                         } else {
-                            // Fallback to Double if it's a long that doesn't fit Int
-                            // or if your Value.Double can represent whole numbers.
-                            DoubleValueSerializer
+                            LongValueSerializer
                         }
                     }
                     element.doubleOrNull != null -> DoubleValueSerializer

--- a/providers/ofrep/src/commonTest/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProviderTest.kt
+++ b/providers/ofrep/src/commonTest/kotlin/dev/openfeature/kotlin/contrib/providers/ofrep/OfrepProviderTest.kt
@@ -18,8 +18,8 @@ import dev.openfeature.kotlin.sdk.ImmutableContext
 import dev.openfeature.kotlin.sdk.OpenFeatureAPI
 import dev.openfeature.kotlin.sdk.Value
 import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents
+import dev.openfeature.kotlin.sdk.events.OpenFeatureProviderEvents.EventDetails
 import dev.openfeature.kotlin.sdk.exceptions.ErrorCode
-import dev.openfeature.kotlin.sdk.exceptions.OpenFeatureError
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
@@ -36,7 +36,6 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -154,7 +153,7 @@ class OfrepProviderTest {
 
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -163,19 +162,15 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
             withClient(provider, defaultEvalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.GeneralError>(exceptionReceived, "The exception is not of type GeneralError")
-                assertEquals(
-                    "Rate limited",
-                    (exceptionReceived as OpenFeatureError.GeneralError).message,
-                    "The exception's message is not correct",
-                )
+                assertEquals(ErrorCode.GENERAL, details?.errorCode)
+                assertEquals("Rate limited", details?.message)
             }
         }
 
@@ -187,7 +182,7 @@ class OfrepProviderTest {
 
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -196,7 +191,7 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
@@ -204,10 +199,7 @@ class OfrepProviderTest {
             withClient(provider, evalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.TargetingKeyMissingError>(
-                    exceptionReceived,
-                    "The exception is not of type TargetingKeyMissingError",
-                )
+                assertEquals(ErrorCode.TARGETING_KEY_MISSING, details?.errorCode)
             }
         }
 
@@ -219,7 +211,7 @@ class OfrepProviderTest {
 
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -228,7 +220,7 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
@@ -236,10 +228,7 @@ class OfrepProviderTest {
             withClient(provider, evalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.TargetingKeyMissingError>(
-                    exceptionReceived,
-                    "The exception is not of type TargetingKeyMissingError",
-                )
+                assertEquals(ErrorCode.TARGETING_KEY_MISSING, details?.errorCode)
             }
         }
 
@@ -253,7 +242,7 @@ class OfrepProviderTest {
                 )
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -262,14 +251,14 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
             withClient(provider, defaultEvalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.InvalidContextError>(exceptionReceived, "The exception is not of type InvalidContextError")
+                assertEquals(ErrorCode.INVALID_CONTEXT, details?.errorCode)
             }
         }
 
@@ -284,7 +273,7 @@ class OfrepProviderTest {
 
             val provider = createOfrepProvider(mockEngine)
             var providerErrorReceived = false
-            var exceptionReceived: Throwable? = null
+            var details: EventDetails? = null
 
             launch {
                 provider
@@ -293,14 +282,14 @@ class OfrepProviderTest {
                     .take(1)
                     .collect {
                         providerErrorReceived = true
-                        exceptionReceived = it.error
+                        details = it.eventDetails
                     }
             }
             runCurrent()
             withClient(provider, defaultEvalCtx) { client ->
                 runCurrent()
                 assertTrue(providerErrorReceived, "ProviderError event was not received")
-                assertIs<OpenFeatureError.ParseError>(exceptionReceived, "The exception is not of type ParseError")
+                assertEquals(ErrorCode.PARSE_ERROR, details?.errorCode)
             }
         }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,6 @@ pluginManagement {
 dependencyResolutionManagement {
     repositories {
         google()
-        mavenLocal()
         mavenCentral()
     }
 }


### PR DESCRIPTION
### Summary
Align **kotlin-sdk-contrib** with **kotlin-sdk** APIs: `StateManagingProvider` lifecycle, `getLongEvaluation`, and `Value.Long` support. Intended to merge once the matching _dev.openfeature:kotlin-sdk_ release is on Maven Central (update _gradle/libs.versions.toml_ accordingly).

### Changes

- `EnvVarProvider` / `OfrepProvider`: implement `StateManagingProvider` via `ProviderStatusTracker` (`status`, `observe()`, lifecycle events).

- `getLongEvaluation` on both providers; OFREP `Value.toPrimitive` / `ValueSerializer` updated for `Long`.

- `EnvVarProvider.onContextSet`: `ProviderReconciling` → `yield()` → `ProviderReady`.

- `OfrepProvider`: lifecycle routed through `statusTracker`; `shutdown` emits not-ready `ProviderError`.