### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -374,7 +374,7 @@ brace-expansion@^1.1.7:
 
 brace-expansion@^2.0.1:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#d63fc9c287469d8cf3a90408d1bc54c184298df3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
   integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
   dependencies:
     balanced-match "^1.0.0"


### PR DESCRIPTION
## Summary

- Updates the tarball hash in the `resolved` URL for `brace-expansion@2.0.2` in `kotlin-js-store/yarn.lock`. The version and `integrity` sha512 are unchanged; the registry re-published the tarball (likely a metadata-only fix), which caused `yarn install` to record a new URL hash on next resolution.
- The `brace-expansion` ReDoS vulnerability (alert #1, low severity) affects `>= 2.0.0, <= 2.0.1`; the lockfile was already on the patched `2.0.2`, so no version bump was needed.

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #1 | `brace-expansion` | **low** | Lockfile already on patched `2.0.2`; corrected stale tarball URL hash so `kotlinNpmInstall` succeeds |